### PR TITLE
Update xppenv and set-dev scripts

### DIFF
--- a/set-common-dev
+++ b/set-common-dev
@@ -1,24 +1,29 @@
 #!/bin/bash
-MODULE="$1"
-if [ -z "$2" ]; then
-  IMPORT="${MODULE}"
-else
-  IMPORT="$2"
+# Usage: ./set-common-dev <repo> [package [org]] [--http]
+# Org defaults to 'pcdshub', package defaults to repo name
+# Defaults to ssh remote, use --http if you prefer that
+
+if [ -z "$1" ]; then
+  echo "Usage: ./set-common-dev <repo> [package [org]]" >&2
+  exit 1
 fi
-if [ -z "$3" ]; then
-  REPO='pcdshub'
-else
-  REPO="$3"
-fi
+
+REPO="$1"
+PACKAGE=${2:-${MODULE}}
+ORG=${3:-"pcdshub"}
 
 HERE=`dirname $(readlink -f $0)`
 mkdir -p "${HERE}/../common/dev/devpath"
 
 pushd "${HERE}/../common/dev"
 
-if [ ! -d "${MODULE}" ]; then
-  git clone "git@github.com:${REPO}/${MODULE}.git"
-  ln -s `readlink -f "${MODULE}/${IMPORT}"` "devpath/${IMPORT}"
+if [ ! -d "${REPO}" ]; then
+  if [[ "$@" =~ "--http" ]]; then
+    git clone "https://github.com/${ORG}/${REPO}.git"
+  else
+    git clone "git@github.com:${ORG}/${REPO}.git"
+  fi
+  ln -s `readlink -f "${REPO}/${PACKAGE}"` "devpath/${PACKAGE}"
 fi
 
 popd

--- a/set-dev
+++ b/set-dev
@@ -1,24 +1,29 @@
 #!/bin/bash
-MODULE="$1"
-if [ -z "$2" ]; then
-  IMPORT="${MODULE}"
-else
-  IMPORT="$2"
+# Usage: ./set-dev <repo> [package [org]] [--http]
+# Org defaults to 'pcdshub', package defaults to repo name
+# Defaults to ssh remote, use --http if you prefer that
+
+if [ -z "$1" ]; then
+  echo "Usage: ./set-dev <repo> [package [org]]" >&2
+  exit 1
 fi
-if [ -z "$3" ]; then
-  REPO='pcdshub'
-else
-  REPO="$3"
-fi
+
+REPO="$1"
+PACKAGE=${2:-${MODULE}}
+ORG=${3:-"pcdshub"}
 
 HERE=`dirname $(readlink -f $0)`
 mkdir -p "${HERE}/dev/devpath"
 
 pushd "${HERE}/dev"
 
-if [ ! -d "${MODULE}" ]; then
-  git clone "git@github.com:${REPO}/${MODULE}.git"
-  ln -s `readlink -f "${MODULE}/${IMPORT}"` "devpath/${IMPORT}"
+if [ ! -d "${REPO}" ]; then
+  if [[ "$@" =~ "--http" ]]; then
+    git clone "https://github.com/${ORG}/${REPO}.git"
+  else
+    git clone "git@github.com:${ORG}/${REPO}.git"
+  fi
+  ln -s `readlink -f "${REPO}/${PACKAGE}"` "devpath/${PACKAGE}"
 fi
 
 popd

--- a/xppenv
+++ b/xppenv
@@ -2,16 +2,32 @@
 # Source this to load the full environment that hutch python uses
 
 # edit this line only
-export CONDA_ENVNAME="pcds-3.2.0"
-export CONDA_BASE="/reg/g/pcds/pyps/conda/py36"
-export HUTCH="xpp"
+USE_LOCAL="1"
+#export CONDA_ENVNAME="pcds-4.2.0"
+export CONDA_ENVNAME="pcds-5.1.1"
 
+export HUTCH="xpp"
+export LOCAL_BASE="/u1/xppopr/conda_envs"
+export NFS_BASE="/cds/group/pcds/pyps/conda/py39"
+
+if [ -n "${USE_LOCAL}" ] && [ -d "${LOCAL_BASE}" ]; then
+  echo "Loading local disk python env ${CONDA_ENVNAME}"
+  source "${LOCAL_BASE}/${CONDA_ENVNAME}/bin/activate"
+else
+  echo "Loading NFS python env ${CONDA_ENVNAME}"
+  source "${NFS_BASE}/etc/profile.d/conda.sh"
+  conda activate "${CONDA_ENVNAME}"
+fi
+          
 unset PYTHONPATH
 unset LD_LIBRARY_PATH
 
-source "${CONDA_BASE}/etc/profile.d/conda.sh"
-conda activate "${CONDA_ENVNAME}"
 HERE=`dirname $(readlink -f $BASH_SOURCE)`
+
+if [ -f "${HERE}/dev/hutch-python/bin/hutch-python" ]; then
+    export PATH="${HERE}/dev/hutch-python/bin:${PATH}"
+fi
+
 export PYTHONPATH="${HERE}:${HERE}/dev/devpath:${HERE}/../common/dev/devpath"
 source pcdsdaq_lib_setup
 export CONDA_PROMPT_MODIFIER="(${HUTCH}-${CONDA_ENVNAME})"


### PR DESCRIPTION
Brings the xpp environment up to newest pcds env release. Makes set-dev scripts easier to use.

The xppenv changes also include an addition that helps when running hutch-python in dev and won't affect xpp3 when complete.

The deployed version of this repo also contains many added files for presets and experiment-specific code. I'll leave that up to @vespos to decide whether or not to commit that. beamline.py should also be committed. I left all of that out and made this PR just an infrastructure update.